### PR TITLE
fix: corrección color del h1 en header

### DIFF
--- a/ProyectoComandosGit/styles.css
+++ b/ProyectoComandosGit/styles.css
@@ -13,6 +13,10 @@ header {
   text-align: center;
 }
 
+header h1 {
+  color: inherit;
+}
+
 .container {
   max-width: 900px;
   margin: auto;


### PR DESCRIPTION
Se corrigió el color del texto en el header para que el título sea visible sobre el fondo oscuro. El h1 antes no se veía debido a herencia de estilos. Se agregó "color: inherit;" al header h1.