### PR TITLE
feat: add git log/show/diff section to HTML

### DIFF
--- a/ProyectoComandosGit/index.html
+++ b/ProyectoComandosGit/index.html
@@ -116,6 +116,7 @@
         <ul>
           <li><strong>git log</strong>: Muestra el historial de commits.</li>
           <li><strong>git show</strong>: Muestra detalles de un commit.</li>
+          <li><strong>git diff</strong>: Muestra las diferencias entre cambios.</li>
         </ul>
       </section>
     </main>

--- a/ProyectoComandosGit/index.html
+++ b/ProyectoComandosGit/index.html
@@ -113,7 +113,9 @@
 
       <section>
         <h2>Historial y Visualización</h2>
-        
+        <ul>
+          <li><strong>git log</strong>: Muestra el historial de commits.</li>
+        </ul>
       </section>
     </main>
     <section class="resource">

--- a/ProyectoComandosGit/index.html
+++ b/ProyectoComandosGit/index.html
@@ -110,6 +110,11 @@
           </li>
         </ul>
       </section>
+
+      <section>
+        <h2>Historial y Visualización</h2>
+        
+      </section>
     </main>
     <section class="resource">
       <h2>Recursos adicionales</h2>

--- a/ProyectoComandosGit/index.html
+++ b/ProyectoComandosGit/index.html
@@ -115,6 +115,7 @@
         <h2>Historial y Visualización</h2>
         <ul>
           <li><strong>git log</strong>: Muestra el historial de commits.</li>
+          <li><strong>git show</strong>: Muestra detalles de un commit.</li>
         </ul>
       </section>
     </main>


### PR DESCRIPTION
This Pull Request adds a new section under the main content explaining three essential Git commands used to visualize repository history and changes:

- `git log`: shows the commit history.
- `git show`: displays detailed information about a specific commit.
- `git diff`: compares changes between commits, branches, or working directory.

The HTML structure was updated to include this section, maintaining consistency with the current layout and CSS.

Closes #xx (if there's a related issue).